### PR TITLE
Bugfix/torch iterable check for iterables of composables

### DIFF
--- a/squirrel/iterstream/multiplexer.py
+++ b/squirrel/iterstream/multiplexer.py
@@ -99,12 +99,12 @@ class Multiplexer(Composable):
         Note that the algorithm stops whenever max_reinits are hit or all composables
         have been reinitialized at least once.
         """
-        super().__init__()
+        super().__init__(source=composables)
         self.mux_strategy = mux_strategy
         if mux_strategy == MultiplexingStrategy.SAMPLING:
             assert sampling_probas is not None
             assert len(sampling_probas) == len(
-                composables
+                self.source
             ), "Need sampling probas and composables to have same number of entries"
 
         self.composables, self.sampling_probas = self._init_composables_and_probas(


### PR DESCRIPTION
# Description
Fixes https://github.com/merantix-momentum/squirrel-core/issues/164

To ensure that `IterableSamplerSource` and `Multiplexer` can be properly used when initiated with `Composables` we add these classes explicitly into the recursive check of `.to_torch_iterable()`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [x] I have read the [contributing guideline doc](https://squirrel-core.readthedocs.io/en/latest/developer/code_of_conduct.html) (external contributors only)
- [x] Lint and unit tests pass locally with my changes
- [x] I have kept the PR small so that it can be easily reviewed  
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All dependency changes have been reflected in the pip requirement files. 
